### PR TITLE
Update sPWM_atmel.ino

### DIFF
--- a/sPWM_atmel/sPWM_atmel.ino
+++ b/sPWM_atmel/sPWM_atmel.ino
@@ -71,7 +71,7 @@ ISR(TIMER1_OVF_vect){
       delay1++;
     }
     // change )duty-cycle every period.
-    OCR1A = OCR1A = lookUp[num];
+    OCR1A = OCR1B = lookUp[num];
     num++;      
 }
 


### PR DESCRIPTION
changed the line 74

before: OCR1A = OCR1A = lookUp[num];
now: OCR1A = OCR1B = lookUp[num];